### PR TITLE
Uses priv directory fordeno install by default

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,1 @@
 import Config
-
-config :deno_ex,
-  default_exectutable_path: "/tmp"

--- a/lib/deno_downloader.ex
+++ b/lib/deno_downloader.ex
@@ -15,7 +15,9 @@ defmodule DenoEx.DenoDownloader do
 
   def install(install_path, permissions)
       when is_binary(install_path) and is_integer(permissions) do
-    with {:ok, [path], []} <- DenoEx.DenoDownloader.download(install_path) do
+    with :ok <- File.mkdir_p(install_path),
+         {:ok, [path], []} <-
+           DenoEx.DenoDownloader.download(install_path) do
       File.chmod(path, permissions)
       {:ok, path}
     end

--- a/lib/deno_ex.ex
+++ b/lib/deno_ex.ex
@@ -8,7 +8,11 @@ defmodule DenoEx do
   @type script_arguments() :: [String.t()]
   @type options() :: keyword()
 
-  @default_executable_path Application.compile_env(:deno_ex, :default_exectutable_path, ".")
+  @default_executable_path Application.compile_env(
+                             :deno_ex,
+                             :default_exectutable_path,
+                             :deno_ex |> :code.priv_dir() |> Path.join("bin")
+                           )
 
   @run_options_schema [
                         deno_path: [


### PR DESCRIPTION
The prriv directory is the directory that is used for application specific files. This is the standard place to put dependencies so we want to follow that convention.

Since we are adding a binary dependency I put it in the bin directory.

https://www.erlang.org/doc/design_principles/applications.html#directory-structure-for-a-released-system