### PR TITLE
Harden script running

### DIFF
--- a/lib/deno_ex.ex
+++ b/lib/deno_ex.ex
@@ -19,6 +19,11 @@ defmodule DenoEx do
                           type: :string,
                           doc: "the path where the deno executable is installed."
                         ],
+                        timeout: [
+                          type: :pos_integer,
+                          default: 100,
+                          doc: "Timeout in milliseconds to wait for the script to run before aborting."
+                        ],
                         allow_env: [
                           type: {:or, [:boolean, list: :string]},
                           doc: """
@@ -50,12 +55,12 @@ defmodule DenoEx do
     #{NimbleOptions.docs(@run_options_schema)}
 
     Please refere to [Deno Permissions](https://deno.com/manual@v1.33.1/basics/permissions) for more details.
-
   """
   @spec run(script, script_arguments, options) :: {:ok, String.t()} | {:error, term()}
   def run(script, script_args \\ [], options \\ []) do
     with {:ok, options} <- NimbleOptions.validate(options, @run_options_schema),
-         {exec_path, deno_options} = Keyword.pop(options, :deno_path, executable_path()) do
+         {exec_path, deno_options} = Keyword.pop(options, :deno_path, executable_path()),
+         {timeout, deno_options} = Keyword.pop(deno_options, :timeout) do
       deno_options = Enum.map(deno_options, &to_command_line_option/1)
 
       deno_path =
@@ -68,18 +73,52 @@ defmodule DenoEx do
         |> List.flatten()
         |> Enum.join(" ")
 
-      {:ok, _pid, identifier} =
+      {:ok, pid, os_pid} =
         deno_path
-        |> :exec.run_link([:stdout, :stderr])
+        |> :exec.run([:stdout, :stderr, :monitor])
 
-      receive do
-        {:stdout, ^identifier, output} ->
-          :exec.stop(identifier)
-          {:ok, output}
+      # Initial state for reduce
+      initial_reduce_results = %{
+        stdout: "",
+        stderr: []
+      }
 
-        {:stderr, ^identifier, output} ->
-          :exec.stop(identifier)
-          {:error, output}
+      result =
+        [nil]
+        |> Stream.cycle()
+        |> Enum.reduce_while(initial_reduce_results, fn _, acc ->
+          receive do
+            {:DOWN, ^os_pid, _, ^pid, {:exit_status, exit_status}} when exit_status != 0 ->
+              error = "Deno script exited with status code #{inspect(exit_status)}\n"
+              existing_errors = Map.get(acc, :stderr, [])
+              {:halt, Map.put(acc, :stderr, [error | existing_errors])}
+
+            {:DOWN, ^os_pid, _, ^pid, :normal} ->
+              {:halt, acc}
+
+            {:stderr, ^os_pid, error} ->
+              error = String.trim(error)
+              existing_errors = Map.get(acc, :stderr, [])
+              {:cont, Map.put(acc, :stderr, [error | existing_errors])}
+
+            {:stdout, ^os_pid, compiled_template_fragment} ->
+              aggregated_template = Map.get(acc, :stdout, "")
+              {:cont, Map.put(acc, :stdout, aggregated_template <> compiled_template_fragment)}
+          after
+            timeout ->
+              :exec.kill(os_pid, :sigterm)
+              error = "Deno script timed out after #{timeout} millisecond(s)"
+              existing_errors = Map.get(acc, :stderr, [])
+              {:halt, Map.put(acc, :stderr, [error | existing_errors])}
+          end
+        end)
+
+      case result do
+        %{stderr: [], stdout: compiled_template} ->
+          {:ok, compiled_template}
+
+        %{stderr: errors} ->
+          {:error, Enum.join(errors, "\n")}
       end
     end
   end

--- a/test/deno_ex_test.exs
+++ b/test/deno_ex_test.exs
@@ -24,6 +24,26 @@ defmodule DenoExTest do
              DenoEx.run("test/support/args_echo.ts", ~w[arg1 arg2])
   end
 
+  test "large outputs" do
+    lines = 9
+    per_line = 100
+
+    expected_output =
+      "a"
+      |> String.duplicate(per_line)
+      |> then(&(&1 <> "\n"))
+      |> String.duplicate(lines)
+
+    assert {:ok, expected_output} ==
+             DenoEx.run("test/support/how_many_chars.ts", ~w[#{lines * per_line} #{per_line}])
+  end
+
+  test "bad exit" do
+    assert {:error, message} = DenoEx.run("test/support/fail.ts", ~w[])
+
+    assert message =~ "exited with status code"
+  end
+
   test "unknown deno arguments" do
     assert {:error,
             %NimbleOptions.ValidationError{

--- a/test/support/fail.ts
+++ b/test/support/fail.ts
@@ -1,0 +1,1 @@
+Deno.exit(1

--- a/test/support/how_many_chars.ts
+++ b/test/support/how_many_chars.ts
@@ -1,0 +1,14 @@
+// Prints out a block of text matching number of chars
+// and the number per line
+// Usage:
+//  deno run how_many_chars.ts 120 10
+//  # prints 120 with 10 per line
+
+const total: number = Number(Deno.args[0])
+const width: number = Number(Deno.args[1])
+const char = "a"
+
+for (let i: number = 0; (total - (width * i)) > 0; i++) {
+  let needed = total - (width * i)
+  console.log("a".repeat(Math.min(needed, width)))
+}


### PR DESCRIPTION
When running a script with a lot of data coming back, the script will write multiple times. We handled only one response before but needed to loop to handle more.

We are also now handling bad exit codes instead of crashing on a bad return.

I was looking into using a two-arity function as an Enumerable for the processing, but it is poorly documented, and I thought we could deal with it at another junction.

@akoutmos pointed out a beautiful way to handle looping with `String.cycle([nil])`. I decided to mimic that code and took it almost entirely from https://github.com/akoutmos/mjml_eex/blob/master/lib/compilers/node.ex#L72-L98

Thank you, @akoutmos, for that pointer.