### PR TITLE
Installs Deno as part of the build process

### DIFF
--- a/lib/deno_ex.ex
+++ b/lib/deno_ex.ex
@@ -21,7 +21,7 @@ defmodule DenoEx do
                         ],
                         timeout: [
                           type: :pos_integer,
-                          default: 100,
+                          default: 5000,
                           doc:
                             "Timeout in milliseconds to wait for the script to run before aborting."
                         ],

--- a/lib/tasks/compile/deno.ex
+++ b/lib/tasks/compile/deno.ex
@@ -1,0 +1,25 @@
+defmodule Mix.Tasks.Compile.Deno do
+  @moduledoc """
+  Installs Deno as part of the build process
+
+  See `DenoEx` for information on configuring the location of
+  deno installation.
+  """
+  use Mix.Task.Compiler
+
+  def run(_) do
+    deno_path = "#{DenoEx.executable_path()}/deno"
+
+    if File.exists?(deno_path) do
+      {:noop, []}
+    else
+      DenoEx.DenoDownloader.install(DenoEx.executable_path(), 0o770)
+
+      if File.exists?(deno_path) do
+        {:ok, ["Deno installation complete"]}
+      else
+        {:error, ["Deno failed to install"]}
+      end
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -11,7 +11,8 @@ defmodule DenoEx.MixProject do
       docs: [
         main: "readme",
         extras: ["README.md"]
-      ]
+      ],
+      compilers: Mix.compilers() ++ [:deno]
     ]
   end
 

--- a/test/deno_ex_test.exs
+++ b/test/deno_ex_test.exs
@@ -2,18 +2,6 @@ defmodule DenoExTest do
   use ExUnit.Case
   doctest DenoEx
 
-  setup_all :ensure_deno_installed
-
-  def ensure_deno_installed(env) do
-    deno_path = "#{DenoEx.executable_path()}/deno"
-
-    unless File.exists?(deno_path) do
-      DenoEx.DenoDownloader.install(DenoEx.executable_path(), 0o770)
-    end
-
-    {:ok, Map.put(env, :install_path, DenoEx.executable_path())}
-  end
-
   test "works with no arguments" do
     assert {:ok, "Hello, world.\n"} ==
              DenoEx.run("test/support/hello.ts", _script_args = [])


### PR DESCRIPTION
To ensure that deno is installed and reduce the users' overhead, we are installing deno as part of the build process. Deno will only be installed if it doesn't already exist in the configured location.

I increased the default timeout because running `mix test` would timeout due to the upfront cost of Deno setting up its environment. I decided on 5000 milliseconds as the new timeout because it is long enough for any system and seems a standard default for timeouts in Elixir.