### PR TITLE
Adds Styler to the project

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,5 +1,6 @@
 # Used by "mix format"
 [
   line_length: 120,
-  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  plugins: [Styler]
 ]

--- a/lib/deno_ex.ex
+++ b/lib/deno_ex.ex
@@ -1,9 +1,7 @@
+env_location_variable = "DENO_LOCATION"
+default_executable_location = :deno_ex |> :code.priv_dir() |> Path.join("bin")
+
 defmodule DenoEx do
-  @default_executable_location :deno_ex |> :code.priv_dir() |> Path.join("bin")
-  @env_location_variable "DENO_LOCATION"
-
-  alias DenoEx.Pipe
-
   @moduledoc """
   DenoEx is used to run javascript and typescript files in a safe environment by utilizing
   [Deno](https://deno.com/runtime).
@@ -19,7 +17,7 @@ defmodule DenoEx do
 
   ### Function Option
 
-       iex> DenoEx.run({:file, Path.join(~w[test support hello.ts])}, [], [deno_location: "#{@default_executable_location}"])
+       iex> DenoEx.run({:file, Path.join(~w[test support hello.ts])}, [], [deno_location: "#{default_executable_location}"])
        {:ok, "Hello, world.#{"\\n"}"}
 
   ### Application Configuration
@@ -31,8 +29,13 @@ defmodule DenoEx do
 
   ### ENV Variable
 
-    `#{@env_location_variable}=path`
+    `#{env_location_variable}=path`
   """
+
+  alias DenoEx.Pipe
+
+  @default_executable_location default_executable_location
+  @env_location_variable env_location_variable
 
   @executable_location Application.compile_env(
                          :deno_ex,

--- a/lib/deno_ex/pipe.ex
+++ b/lib/deno_ex/pipe.ex
@@ -1,12 +1,12 @@
 defmodule DenoEx.Pipe do
-  @derive {Inspect, only: [:status]}
   @moduledoc """
   The DenoEx pipe.
 
   This module defines a struct and the main functions for working with deno pipes
   and their responses.
   """
-  @run_options_schema [
+  @derive {Inspect, only: [:status]}
+  @run_options_schema NimbleOptions.new!(
                         deno_location: [
                           type: :string,
                           doc: """
@@ -107,12 +107,8 @@ defmodule DenoEx.Pipe do
                           `[Path.t()]`: A list of files that can be read
                           """
                         ],
-                        allow_all: [
-                          type: :boolean,
-                          doc: "Turns on all options and bypasses all security measures"
-                        ]
-                      ]
-                      |> NimbleOptions.new!()
+                        allow_all: [type: :boolean, doc: "Turns on all options and bypasses all security measures"]
+                      )
 
   @typedoc "status of the pipe"
   @type status :: :initialized | :running | {:exited, :normal | pos_integer()} | :timeout

--- a/lib/tasks/install.ex
+++ b/lib/tasks/install.ex
@@ -1,20 +1,18 @@
-defmodule Mix.Tasks.DenoEx.Install do
-  use Mix.Task
-
-  @shortdoc "Installs Deno"
-
-  @options_schema [
-    path: [
-      type: :string,
-      default: DenoEx.executable_location(),
-      doc: "The path to install deno."
-    ],
-    chmod: [
-      type: :string,
-      default: "770",
-      doc: "The permissions that will be set on the deno binary. In octal format."
-    ]
+options_schema = [
+  path: [
+    type: :string,
+    default: DenoEx.executable_location(),
+    doc: "The path to install deno."
+  ],
+  chmod: [
+    type: :string,
+    default: "770",
+    doc: "The permissions that will be set on the deno binary. In octal format."
   ]
+]
+
+defmodule Mix.Tasks.DenoEx.Install do
+  @shortdoc "Installs Deno"
 
   @moduledoc """
   A mix task that installs Deno into your project.
@@ -25,8 +23,12 @@ defmodule Mix.Tasks.DenoEx.Install do
 
   # Options
 
-    #{NimbleOptions.docs(@options_schema)}
+    #{NimbleOptions.docs(options_schema)}
   """
+
+  use Mix.Task
+
+  @options_schema options_schema
 
   @impl true
   def run(args) do

--- a/mix.exs
+++ b/mix.exs
@@ -91,7 +91,8 @@ defmodule DenoEx.MixProject do
       {:excoveralls, "~> 0.16.1", only: [:test, :dev], runtime: false},
       {:doctor, "~> 0.21.0", only: :dev},
       {:credo, "~> 1.7.0", only: :dev},
-      {:dialyxir, "~> 1.3.0", only: :dev, runtime: false}
+      {:dialyxir, "~> 1.3.0", only: :dev, runtime: false},
+      {:styler, "~> 0.7.11", only: :dev, runtime: false}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -30,5 +30,6 @@
   "recon": {:hex, :recon, "2.3.6", "2bcad0cf621fb277cabbb6413159cd3aa30265c2dee42c968697988b30108604", [:rebar3], [], "hexpm", "f55198650a8ec01d3efc04797abe550c7d023e7ff8b509f373cf933032049bd8"},
   "recon_ex": {:hex, :recon_ex, "0.9.1", "51558b6eb347753dcf9c884ba68d49dbbec607fc4296815b72a0c8995d5d3203", [:mix], [{:recon, "~> 2.3.1", [hex: :recon, repo: "hexpm", optional: false]}], "hexpm", "ca124759162c082adbb29078eadb9ab102425493c94387221d1e11acd0e050f7"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.6", "cf344f5692c82d2cd7554f5ec8fd961548d4fd09e7d22f5b62482e5aeaebd4b0", [:make, :mix, :rebar3], [], "hexpm", "bdb0d2471f453c88ff3908e7686f86f9be327d065cc1ec16fa4540197ea04680"},
+  "styler": {:hex, :styler, "0.7.11", "e1e629bc5a2d5b070b75a54c9676726d4fa57a9416a2972db0c51fa1d3a6638d", [:mix], [], "hexpm", "db9c7dd64c94c8e829cf8159cb2355b0a4e5069d9d9c7281136af837a7ccdddf"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
 }

--- a/test/deno_ex/pipe_test.exs
+++ b/test/deno_ex/pipe_test.exs
@@ -1,6 +1,8 @@
 defmodule DenoEx.PipeTest do
   use ExUnit.Case, async: true
+
   alias DenoEx.Pipe
+
   doctest Pipe
 
   @script Path.join(~w[test support args_echo.ts])
@@ -53,7 +55,7 @@ defmodule DenoEx.PipeTest do
 
   test "support chardata scripts" do
     assert %{status: :running} =
-             {:stdin, ["console.log(", 'hello', ?)]}
+             {:stdin, ["console.log(", ~c"hello", ?)]}
              |> Pipe.new([])
              |> Pipe.run()
   end

--- a/test/deno_ex_test.exs
+++ b/test/deno_ex_test.exs
@@ -7,12 +7,12 @@ defmodule DenoExTest do
 
   def create_test_file(env) do
     tmp_dir = System.tmp_dir!()
-    filename = System.monotonic_time() |> to_string()
+    filename = to_string(System.monotonic_time())
 
     path = Path.join(tmp_dir, filename)
     _ = File.rm(path)
 
-    content = System.monotonic_time() |> to_string()
+    content = to_string(System.monotonic_time())
 
     File.write!(path, content)
 


### PR DESCRIPTION
Styler fixes some of the credo checks that can be automated, so we don't have to think about it. It also rearranges the file into a standard order. This helps because while we are working, we can stay at the same level as the code we are writing and add our imports and everything there. Then when we format, it will move those to the correct locations so we never have to think about it again.

There is one side effect. Since some of our module-attributes depended on other module-attributes, i.e., documentation, we need to move those to bare identifiers outside the module. These identifiers only exist during the compilation process.

I believe this may help keep things consistent even with outside contributors and without putting as much onus on them.