### PR TITLE
Deno vendor support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ deno_ex-*.tar
 # Dialyzer PLT files
 /priv/plts/*.plt
 /priv/plts/*.plt.hash
+
+# Used in a real DenoEx install, but not to be checked in on working with DenoEx.
+/priv/deno

--- a/README.md
+++ b/README.md
@@ -29,10 +29,17 @@
 
 # Contents
 
-- [Introduction](#introduction)
-- [Installation](#installation)
-- [Supporting DenoEx](#supporting-denoex)
-- [Using DenoEx](#using-denoex)
+- [Contents](#contents)
+  - [Introduction](#introduction)
+  - [Installation](#installation)
+    - [Installing the Runtime](#installing-the-runtime)
+    - [Using DenoEx to Install Copies of the Runtime](#using-denoex-to-install-copies-of-the-runtime)
+  - [Supporting DenoEx](#supporting-denoex)
+    - [Gold Sponsors](#gold-sponsors)
+    - [Silver Sponsors](#silver-sponsors)
+    - [Bronze Sponsors](#bronze-sponsors)
+  - [Using DenoEx](#using-denoex)
+    - [Handling Dependencies](#handling-dependencies)
 
 ## Introduction
 
@@ -111,3 +118,28 @@ Open iex using `iex -S mix` and then run the TypeScript file:
 ```elixir
 iex > DenoEx.run({:file, "path/to/file.ts"})
 ```
+
+### Handling Dependencies
+
+Scripts download dependencies on their first run. The output from downloading ends up in the scripts output. In
+order to avoid the time to download and vendoring at runtime we encourage users to vendor their dependencies.
+You will first need to configure vendoring.
+
+```elixir
+config :deno_ex,
+  scripts_path: [
+    Path.join(~w[test support **]),
+    Path.join(~w[my_scripts hello.ts])
+  ]
+```
+
+`scripts_path` can be a list of paths to scripts or wildcards.
+
+`mix deno_ex.deps.get` will load all dependencies in the cache and update the lock file.
+
+
+In order to ensure that your scripts use the dependencies that are cached and locked your
+scripts need a few more arguments.
+
+`cached_only: true` - tells the script to only used cached dependencies
+`lock: path_to_lockfile` - tells the script where the lock file is located

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,1 +1,4 @@
 import Config
+
+config :deno_ex,
+  scripts_path: Path.join(~w[test support])

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,1 +1,4 @@
 import Config
+
+config :deno_ex,
+  scripts_path: Path.join(~w[test support *.ts])

--- a/coveralls.json
+++ b/coveralls.json
@@ -1,4 +1,4 @@
 {
-  "skip_files": ["test/"],
+  "skip_files": ["test/", "lib/tasks/install.ex", "lib/tasks/deps/get.ex"],
   "minimum_coverage": 65
 }

--- a/lib/deno_downloader.ex
+++ b/lib/deno_downloader.ex
@@ -4,9 +4,14 @@ defmodule DenoEx.DenoDownloader do
   """
 
   use OctoFetch,
-    latest_version: "1.33.4",
+    latest_version: "1.34.3",
     github_repo: "denoland/deno",
     download_versions: %{
+      "1.34.3" => [
+        {:darwin, :arm64, "fe48d39286fe973211500f6426300181a8f19103dd278dcbe679a586b14d8eb6"},
+        {:darwin, :amd64, "d25b6f0de52ccdf5818df184e5c795a01d06e5e28c14c4845c1ad8272c2eadad"},
+        {:linux, :amd64, "f2d496a83509937b7e4e0c9316355f2ff4efcf6042c2cf297919e09e42645c39"}
+      ],
       "1.33.4" => [
         {:darwin, :arm64, "ea504cac8ba53ef583d0f912d7834f4bff88eb647cfb10cb1dd24962b1dc062d"},
         {:darwin, :amd64, "1e2d79b4a237443e201578fc825052245d2a71c9a17e2a5d1327fa35f9e8fc0e"},

--- a/lib/tasks/compile/deno.ex
+++ b/lib/tasks/compile/deno.ex
@@ -7,14 +7,14 @@ defmodule Mix.Tasks.Compile.Deno do
   """
   use Mix.Task.Compiler
 
-  @impl true
+  @impl Mix.Task.Compiler
   def run(_) do
-    deno_path = Path.join(DenoEx.executable_location(), "deno")
+    deno_path = Path.join(DenoEx.executable_path(), "deno")
 
     if File.exists?(deno_path) do
       {:noop, []}
     else
-      _ = DenoEx.DenoDownloader.install(DenoEx.executable_location(), 0o770)
+      _ = DenoEx.DenoDownloader.install(DenoEx.executable_path(), 0o770)
 
       if File.exists?(deno_path) do
         {:ok, ["Deno installation complete"]}

--- a/lib/tasks/deps/get.ex
+++ b/lib/tasks/deps/get.ex
@@ -1,0 +1,34 @@
+defmodule Mix.Tasks.DenoEx.Deps.Get do
+  @moduledoc """
+  A mix task for loading deno dependencies cache
+
+  This delegates to `deno cache`
+  """
+  use Mix.Task
+
+  @shortdoc """
+  Creates a lock file of the dependecies for deno
+  """
+
+  @requirements ["app.config"]
+
+  @doc false
+  @impl Mix.Task
+  def run(args) do
+    app = Keyword.get(Mix.Project.config(), :app)
+    lock_file_path = DenoEx.lock_file_path(app)
+    lock_file_dir = Path.dirname(lock_file_path)
+
+    unless File.exists?(lock_file_dir) do
+      File.mkdir_p!(lock_file_dir)
+    end
+
+    scripts =
+      Application.get_env(:deno_ex, :scripts_path)
+      |> List.wrap()
+      |> Enum.flat_map(&Path.wildcard/1)
+
+    :ok = DenoEx.lock_dependencies(scripts, lock_file_path, args)
+    Mix.shell().info("Created #{lock_file_path}")
+  end
+end

--- a/lib/tasks/install.ex
+++ b/lib/tasks/install.ex
@@ -6,7 +6,7 @@ defmodule Mix.Tasks.DenoEx.Install do
   @options_schema [
     path: [
       type: :string,
-      default: DenoEx.executable_location(),
+      default: DenoEx.executable_path(),
       doc: "The path to install deno."
     ],
     chmod: [

--- a/test/deno_ex/pipe_test.exs
+++ b/test/deno_ex/pipe_test.exs
@@ -22,7 +22,7 @@ defmodule DenoEx.PipeTest do
              Pipe.new({:file, @script}, ~w[arg], allow_env: ~w[USER SHELL])
 
     assert command == [
-             Path.join(DenoEx.executable_location(), "deno"),
+             Path.join(DenoEx.executable_path(), "deno"),
              "run",
              ["--allow-env=USER,SHELL"],
              @script,
@@ -53,7 +53,7 @@ defmodule DenoEx.PipeTest do
 
   test "support chardata scripts" do
     assert %{status: :running} =
-             {:stdin, ["console.log(", 'hello', ?)]}
+             {:stdin, ["console.log(", ~c"hello", ?)]}
              |> Pipe.new([])
              |> Pipe.run()
   end


### PR DESCRIPTION
Sometimes we don't want the dependencies to be downloaded at runtime. It
is an unsafe practice. The other issue is that when dependencies are
downloaded at runtime, the output ends up in the script output. This adds
extra work to ignore that part of the output. Vendoring and locking are
more secure and better for deployments.