### PR TITLE
Add `:ssl` in extra_applications

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,7 @@ defmodule DenoEx.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:logger]
+      extra_applications: [:logger, :ssl]
     ]
   end
 


### PR DESCRIPTION
Quick fix to allow the lib to work with Elixir 1.15.